### PR TITLE
Fix InvalidMoveException not being thrown.

### DIFF
--- a/Pawn.java
+++ b/Pawn.java
@@ -71,9 +71,10 @@ public class Pawn extends PieceAbstract
             //set flag for moving forwards
             movingForward = true;
         }
-        //if nothing between start and end, not occupied by friendly piece, and
-        //moving in the same column
-        if(notBetween && occupyingPiece < 0 && movingForward && x == this.x)
+        //if nothing between start and end, not occupied by friendly piece,
+        //moving in the same column, and not trying to move two spaces after already moving
+        if(notBetween && occupyingPiece < 0 && movingForward && x == this.x &&
+            (Math.abs(y - this.y) == 1 || (Math.abs(y - this.y) == 2 && notMoved)))
         {
             //if moving one space
             if(Math.abs(y - this.y) == 1)

--- a/PieceAbstract.java
+++ b/PieceAbstract.java
@@ -291,7 +291,7 @@ public abstract class PieceAbstract
                     occupyingPiece = i;
             }
         }
-        if(notBetween && occupyingPiece < 0 && (this.x == x || this.y == y))
+        if(notBetween && occupyingPiece < 0 && (this.x == x || this.y == y) && (this.x != x && this.y != y))
         {
             //only perform move if not checking check status of other player's king
             if(!performingCheck)
@@ -300,7 +300,7 @@ public abstract class PieceAbstract
                 this.y = y;
             }
         }
-        else if (occupyingPiece >= 0 && notBetween && mainFrame.pieces[occupyingPiece].getPlayer() != player)
+        else if (occupyingPiece >= 0 && notBetween && mainFrame.pieces[occupyingPiece].getPlayer() != player && (this.x != x && this.y != y))
         {
             //only perform move if not checking check status of other player's king
             if(!performingCheck)


### PR DESCRIPTION
Fix InvalidMoveException not being thrown by Pawns and Rooks. Rooks
previously wouldn't throw the exception if they were moved onto the
square they were already on, and Pawns wouldn't throw the exception if
the player tried to move them forwards more than the number of squares
allowed.