### PR TITLE
Improve performance when repainting the board.

### DIFF
--- a/Bishop.java
+++ b/Bishop.java
@@ -1,7 +1,4 @@
 //class file for Bishop chess pieces.
-import java.io.*;
-import javax.imageio.*;
-import java.awt.image.*;
 
 public class Bishop extends PieceAbstract
 {
@@ -9,12 +6,6 @@ public class Bishop extends PieceAbstract
     public Bishop(int x, int y, char player, MainFrame mainFrame, PieceAbstract[] pieces)
     {
         super(x, y, player, mainFrame, pieces);
-    }
-    //return the image associated with this Bishop
-    public BufferedImage getImage()
-        throws IOException
-    {
-        return ImageIO.read(new File("images/"+player+"Bishop.png"));
     }
     //move this Bishop according to the appropriate rules
     public void move(int x, int y, boolean check)

--- a/BoardPanel.java
+++ b/BoardPanel.java
@@ -55,21 +55,13 @@ public class BoardPanel extends JPanel
            //character cast is using ascii values
            g.drawString("" + (char)(97 + i), ((i + 1) * 100) - 15, 795);
         }
-        try
+        for(int i = 0; i < pieces.length; i++)
         {
-            for(int i = 0; i < pieces.length; i++)
-            {
-                if(i != selected && !pieces[i].isCaptured())
-                    g.drawImage(pieces[i].getImage(), pieces[i].getX()*100, pieces[i].getY()*100, null);
-            }
-            if(selected != -1)
-                g.drawImage(pieces[selected].getImage(), currX, currY, null);
+            if(i != selected && !pieces[i].isCaptured())
+                g.drawImage(pieces[i].getImage(), pieces[i].getX()*100, pieces[i].getY()*100, null);
         }
-        catch(IOException ioe)
-        {
-            System.out.printf("%s%n%nTerminating.", ioe.getMessage());
-            System.exit(1);
-        }
+        if(selected != -1)
+            g.drawImage(pieces[selected].getImage(), currX, currY, null);
     }
     private class MouseHandler extends MouseAdapter
     {

--- a/King.java
+++ b/King.java
@@ -1,7 +1,4 @@
 //class file for King chess pieces.
-import java.io.*;
-import javax.imageio.*;
-import java.awt.image.*;
 
 public class King extends PieceAbstract
 {
@@ -19,11 +16,6 @@ public class King extends PieceAbstract
     public King(int x, int y, char player, MainFrame mainFrame, PieceAbstract[] pieces)
     {
         super(x, y, player, mainFrame, pieces);
-    }
-    public BufferedImage getImage()
-        throws IOException
-    {
-        return ImageIO.read(new File("images/"+player+"King.png"));
     }
     //allows other classes to change this variable
     public void setCheckCaptured(boolean checkCaptured)

--- a/Knight.java
+++ b/Knight.java
@@ -1,7 +1,4 @@
 //class file for Knight chess pieces
-import java.io.*;
-import javax.imageio.*;
-import java.awt.image.*;
 
 public class Knight extends PieceAbstract
 {
@@ -9,12 +6,6 @@ public class Knight extends PieceAbstract
     public Knight(int x, int y, char player, MainFrame mainFrame, PieceAbstract[] pieces)
     {
         super(x, y, player, mainFrame, pieces);
-    }
-    //return the image associated with this Knight
-    public BufferedImage getImage()
-        throws IOException
-    {
-        return ImageIO.read(new File("images/"+player+"Knight.png"));
     }
     //move this Knight according to the appropriate rules
     public void move(int x, int y, boolean performingCheck)

--- a/Pawn.java
+++ b/Pawn.java
@@ -1,7 +1,4 @@
 //class file for Pawn chess pieces
-import java.io.*;
-import javax.imageio.*;
-import java.awt.image.*;
 
 public class Pawn extends PieceAbstract
 {
@@ -28,12 +25,6 @@ public class Pawn extends PieceAbstract
     public void setEnPassant(boolean enPassant)
     {
         this.enPassant = enPassant;
-    }
-    //return the image associated with this Pawn
-    public BufferedImage getImage()
-        throws IOException
-    {
-        return ImageIO.read(new File("images/"+player+"Pawn.png"));
     }
     //set notmoved variable
     public void setNotMoved(boolean notMoved)

--- a/PieceAbstract.java
+++ b/PieceAbstract.java
@@ -1,5 +1,6 @@
 //abstract class file providing default method implementations.
 import java.io.*;
+import javax.imageio.*;
 import java.awt.image.*;
 public abstract class PieceAbstract
 {
@@ -10,6 +11,7 @@ public abstract class PieceAbstract
     boolean captured;
     MainFrame mainFrame;
     PieceAbstract[] pieces;
+    BufferedImage picture;
 
     //counters for captured pieces
     private static int wPawnCap = 0, wRookCap = 0, wKnightCap = 0, wBishopCap = 0, wQueenCap = 0;
@@ -26,6 +28,37 @@ public abstract class PieceAbstract
         this.oldX = x;
         this.oldY = y;
         captured = false;
+
+        //read appropriate image
+        try
+        {
+            String imagePath = "images/" + player;
+
+            if(this instanceof King)
+                imagePath += "King.png";
+
+            else if(this instanceof Queen)
+                imagePath += "Queen.png";
+
+            else if(this instanceof Rook)
+                imagePath += "Rook.png";
+
+            else if(this instanceof Bishop)
+                imagePath += "Bishop.png";
+
+            else if(this instanceof Knight)
+                imagePath += "Knight.png";
+            
+            else if(this instanceof Pawn)
+                imagePath += "Pawn.png";
+            
+            picture = ImageIO.read(new File(imagePath));
+        }
+        catch(IOException ioe)
+        {
+            System.out.println(ioe);
+            System.exit(1);
+        }
     }
     //used to retrieve count of captured pieces
     public static int getCapturedCount(int pieceType)
@@ -126,8 +159,10 @@ public abstract class PieceAbstract
         return player;
     }
     //used to get the image associated with this piece
-    public abstract BufferedImage getImage()
-        throws IOException;
+    public BufferedImage getImage()
+    {
+        return picture;
+    }
 
     //used to get the x position of this piece
     public int getX()

--- a/Queen.java
+++ b/Queen.java
@@ -1,7 +1,4 @@
 // Class file for Queen chess pieces.
-import java.io.*;
-import javax.imageio.*;
-import java.awt.image.*;
 
 public class Queen extends PieceAbstract
 {
@@ -9,12 +6,6 @@ public class Queen extends PieceAbstract
     public Queen(int x, int y, char player, MainFrame mainFrame, PieceAbstract[] pieces)
     {
         super(x, y, player, mainFrame, pieces);
-    }
-    //get the image associated with this Queen
-    public BufferedImage getImage()
-        throws IOException
-    {
-        return ImageIO.read(new File("images/"+player+"Queen.png"));
     }
     //move this Queen, following the appropriate rules
     public void move(int x, int y, boolean check)

--- a/Rook.java
+++ b/Rook.java
@@ -1,7 +1,4 @@
 // Class file for Rook chess pieces.
-import java.io.*;
-import javax.imageio.*;
-import java.awt.image.*;
 
 public class Rook extends PieceAbstract
 {
@@ -12,12 +9,6 @@ public class Rook extends PieceAbstract
     public Rook(int x, int y, char player, MainFrame mainFrame, PieceAbstract[] pieces)
     {
         super(x, y, player, mainFrame, pieces);
-    }
-    //return the image associated with this Rook
-    public BufferedImage getImage()
-        throws IOException
-    {
-        return ImageIO.read(new File("images/"+player+"Rook.png"));
     }
     //move this Rook according to the appropriate rules
     public void move(int x, int y, boolean check)


### PR DESCRIPTION
Store each piece's image instead of fetching a new copy everytime the
board is repainted to improve performance.