### PR TITLE
Fix Possible Network Deadlock

### DIFF
--- a/MainFrame.java
+++ b/MainFrame.java
@@ -170,6 +170,7 @@ public class MainFrame extends JFrame
     public void setGameover(boolean gameOver)
     {
         this.gameOver = gameOver;
+        menuPanel.toggleNewGameButton();
     }
     //update the menus in the menu panel
     public void updateMenu()

--- a/MainFrame.java
+++ b/MainFrame.java
@@ -146,6 +146,7 @@ public class MainFrame extends JFrame
         initializePieces();
         turn = 'W';
         menuPanel.updateMenuLabels();
+        menuPanel.setNewGameEnabled(false);
         gameOver = false;
 
         historyPanel.clearHistory();
@@ -170,7 +171,7 @@ public class MainFrame extends JFrame
     public void setGameover(boolean gameOver)
     {
         this.gameOver = gameOver;
-        menuPanel.toggleNewGameButton();
+        menuPanel.setNewGameEnabled(true);
     }
     //update the menus in the menu panel
     public void updateMenu()
@@ -313,6 +314,7 @@ public class MainFrame extends JFrame
                 }
                 connected=false;
                 statusLabel.setText("Game ended.");
+                menuPanel.setNewGameEnabled(true);
                 if(serverSocket!=null) serverSocket.close();
                 serverSocket=null;
                 s.close();
@@ -363,6 +365,7 @@ public class MainFrame extends JFrame
                 }
                 connected=false;
                 statusLabel.setText("Game ended.");
+                menuPanel.setNewGameEnabled(true);
                 s.close();
             }
             catch(IOException ioe)

--- a/MenuPanel.java
+++ b/MenuPanel.java
@@ -28,6 +28,7 @@ public class MenuPanel extends JPanel
         //new game button 
         newGameButton = new JButton("New Game");
         newGameButton.addActionListener(bh);
+        newGameButton.setEnabled(false);
         add(newGameButton);
 
         //forfeit button
@@ -105,6 +106,10 @@ public class MenuPanel extends JPanel
 
         //update counts in this panel
         redrawInterface();
+    }
+    public void toggleNewGameButton()
+    {
+        newGameButton.setEnabled(!newGameButton.isEnabled());
     }
     private void redrawInterface()
     {

--- a/MenuPanel.java
+++ b/MenuPanel.java
@@ -107,9 +107,10 @@ public class MenuPanel extends JPanel
         //update counts in this panel
         redrawInterface();
     }
-    public void toggleNewGameButton()
+    //change enabled state of newGameButton
+    public void setNewGameEnabled(boolean enabled)
     {
-        newGameButton.setEnabled(!newGameButton.isEnabled());
+        newGameButton.setEnabled(enabled);
     }
     private void redrawInterface()
     {


### PR DESCRIPTION
Disable the new game button when the game is not over (neither player
is in checkmate and neither player has forfeited).